### PR TITLE
Update link to avalon site

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,7 +47,7 @@ extra:
   font: false
   social:
     - type: globe
-      link: http://avalon.com
+      link: http://getavalon.github.io
     - type: github-alt
       link: https://github.com/getavalon
     - type: twitter


### PR DESCRIPTION
Update the link to main avalon site - currently linking to Avalon capital.