### PR TITLE
Update guide to install PyQt5 5.12 to match VFX platform

### DIFF
--- a/pages/2.0/guides.md
+++ b/pages/2.0/guides.md
@@ -47,7 +47,7 @@ In order to use Avalon, here's what you need.
 Ensure you have PyQt5 installed.
 
 ```bash
-pip install PyQt5==5.7.1
+pip install PyQt5==5.12
 ```
 
 Avalon may run with newer version of PyQt5, but if you encounter any issues, please revert to this exact version.


### PR DESCRIPTION
This updates the installation guide to "hint" at installing `PyQt5` with a newer version `5.12`. This then matches the current recommendation of [VFXPlatform](https://vfxplatform.com/) for 2019/2020.

Another, likely more important reason, is that with `5.7.1` any user trying to install with Python 3.7 failed to pass this step because that version is not available for Python 3.7. By installing `5.12` we allow for users to continue without errors.

---

Be aware that #7 would be important alongside this update, because otherwise the user will run into issues with the older Avalon that was pulled being incompatible with this newer PyQt5 version which was fixed in the Launcher with: https://github.com/getavalon/launcher/pull/44/files - otherwise the user would run into this error:

```
file:///C:/Users/Roy/Downloads/avalon-setup/git/avalon-launcher/launcher/res/qml/main.qml:79 Type MyButton unavailable
file:///C:/Users/Roy/Downloads/avalon-setup/git/avalon-launcher/launcher/res/qml/MyButton.qml:8 Cannot override FINAL property
```