### PR TITLE
Add "Who is using Avalon?"

### DIFF
--- a/pages/2.0/overview.md
+++ b/pages/2.0/overview.md
@@ -54,4 +54,8 @@ It overlaps into people management by hooking into tasks supplied via production
 - [Submarine](https://www.submarine.nl/)
 - [Job, Joris en Marieke](https://www.jobjorisenmarieke.nl/)
 
+!!! hint "Missing your name?"
+
+    Missing your name? Let us know on [Avalon Gitter](https://gitter.im/getavalon/Lobby) or set up a PR to [`getavalon/docs`](https://github.com/getavalon/docs).
+
 <br>

--- a/pages/2.0/overview.md
+++ b/pages/2.0/overview.md
@@ -2,7 +2,7 @@
 
 # Home
 
-Avalon is an end-to-end, free and open source data pipeline powering [Mindbender](http://mindbender.com) and [Colorbleed](http://colorbleed.nl) during the production of computer generated imagery.
+Avalon is an end-to-end, free and open source data pipeline powering [Animation and VFX studios](#who-is-using-avalon) during the production of computer generated imagery.
 
 - See [What is Avalon?](#what-is-avalon) for details.
 
@@ -44,4 +44,14 @@ It overlaps into people management by hooking into tasks supplied via production
 
 <br>
 <br>
+
+## Who is using Avalon?
+
+- [Colorbleed](https://www.colorbleed.nl/)
+- [Moonshine VFX](https://www.moonshine.tw/)
+- [Kredenc](http://kredenc.studio/)
+- [Bumpybox](http://www.bumpybox.com/)
+- [Submarine](https://www.submarine.nl/)
+- [Job, Joris en Marieke](https://www.jobjorisenmarieke.nl/)
+
 <br>


### PR DESCRIPTION
This is a draft to add a chapter on who is known to be using Avalon.

The list is longer, however I haven't had clearance from more parties yet to add their name to this list so for now they are ommitted. It's trivial to set up additional PRs if we want to add them later.

#### Sorting

The sorting currently is slightly random, but I have somewhat sorted it by known order of usage (e.g. from longest users to newest users)

#### Missing your name?

I wasn't sure whether to add a note like "Missing your name?" so I have ommitted that for now too. Otherwise we can add something like:

*Missing your name? Let us know on [Avalon Gitter](https://gitter.im/getavalon/Lobby) or set up a PR to [`getavalon/docs`](https://github.com/getavalon/docs).*

---

@davidlatwe (couldn't request a review from you here, so just tagging instead)